### PR TITLE
Make corner radius configurable on each BottomNavyBarItem

### DIFF
--- a/lib/bottom_navy_bar.dart
+++ b/lib/bottom_navy_bar.dart
@@ -35,7 +35,7 @@ class BottomNavyBar extends StatelessWidget {
       padding: EdgeInsets.only(left: 12),
       decoration: BoxDecoration(
         color: isSelected ? item.activeColor.withOpacity(0.2) : backgroundColor,
-        borderRadius: BorderRadius.all(Radius.circular(50)),
+        borderRadius: BorderRadius.all(Radius.circular(item.cornerActiveRadius)),
       ),
       child: ListView(
         shrinkWrap: true,
@@ -111,17 +111,15 @@ class BottomNavyBar extends StatelessWidget {
   }
 }
 
-class BottomNavyBarItem {
+class CustomBottomNavyBarItem {
   final Icon icon;
   final Text title;
   final Color activeColor;
   final Color inactiveColor;
+  final double cornerActiveRadius;
 
-  BottomNavyBarItem(
-      {@required this.icon,
-        @required this.title,
-        this.activeColor = Colors.blue,
-        this.inactiveColor}) {
+  CustomBottomNavyBarItem(
+      {@required this.icon, @required this.title, this.activeColor = Colors.blue, this.inactiveColor, this.cornerActiveRadius = 50}) {
     assert(icon != null);
     assert(title != null);
   }


### PR DESCRIPTION
Will default to 50 for radius as per the current code. But it can now be configured on a BottomNavyBarItem by BottomNavyBarItem case, this allows for squares with rounded corners rather than just having to have the pill style.

I have forked and run this code in my project (see below)

![image](https://user-images.githubusercontent.com/21989833/65551556-27b7a000-df1a-11e9-9640-805c16eb56f1.png)
