### PR TITLE
don't use specific widgets

### DIFF
--- a/lib/bottom_navy_bar.dart
+++ b/lib/bottom_navy_bar.dart
@@ -171,8 +171,8 @@ class _ItemWidget extends StatelessWidget {
 }
 
 class BottomNavyBarItem {
-  final Icon icon;
-  final Text title;
+  final Widget icon;
+  final Widget title;
   final Color activeColor;
   final Color inactiveColor;
   final TextAlign textAlign;


### PR DESCRIPTION
fixes #54 

- Since the documentation example uses Icon and Text. It is already clear that the API was designed for those widgets. We should follow flutter widget composition model to allow any widget.