### PR TITLE
Add support to override item width and item selected width

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A beautiful and animated bottom navigation. The navigation bar use your current 
 - `iconSize` - the item icon's size
 - `items` - navigation items, required more than one item and less than six
 - `selectedIndex` - the current item index. Use this to change the selected item. Default to zero
+- `selectedWidth` - changes the width of the selected item. Defaults to 130.
 - `onItemSelected` - required to listen when a item is tapped it provide the selected item's index
 - `backgroundColor` - the navigation bar's background color
 - `showElevation` - if false the appBar's elevation will be removed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ A beautiful and animated bottom navigation. The navigation bar use your current 
 - `iconSize` - the item icon's size
 - `items` - navigation items, required more than one item and less than six
 - `selectedIndex` - the current item index. Use this to change the selected item. Default to zero
-- `selectedWidth` - changes the width of the selected item. Defaults to 130.
+- `itemWidth` - changes the width of the  item. Defaults to 50.
+- `itemSelectedWidth` - changes the width of the selected item. Defaults to 130.
 - `onItemSelected` - required to listen when a item is tapped it provide the selected item's index
 - `backgroundColor` - the navigation bar's background color
 - `showElevation` - if false the appBar's elevation will be removed

--- a/lib/bottom_navy_bar.dart
+++ b/lib/bottom_navy_bar.dart
@@ -13,6 +13,7 @@ class BottomNavyBar extends StatelessWidget {
   BottomNavyBar({
     Key key,
     this.selectedIndex = 0,
+    this.selectedWidth = 130,
     this.showElevation = true,
     this.iconSize = 24,
     this.backgroundColor,
@@ -33,6 +34,9 @@ class BottomNavyBar extends StatelessWidget {
   /// The selected item is index. Changing this property will change and animate
   /// the item being selected. Defaults to zero.
   final int selectedIndex;
+
+  // The width of selected item. Defaults to 130.
+  final int selectedWidth;
 
   /// The icon size of all items. Defaults to 24.
   final double iconSize;
@@ -103,6 +107,7 @@ class BottomNavyBar extends StatelessWidget {
                   itemCornerRadius: itemCornerRadius,
                   animationDuration: animationDuration,
                   curve: curve,
+                  selectedWidth: selectedWidth,
                 ),
               );
             }).toList(),
@@ -121,6 +126,7 @@ class _ItemWidget extends StatelessWidget {
   final double itemCornerRadius;
   final Duration animationDuration;
   final Curve curve;
+  final int selectedWidth;
 
   const _ItemWidget({
     Key key,
@@ -130,6 +136,7 @@ class _ItemWidget extends StatelessWidget {
     @required this.animationDuration,
     @required this.itemCornerRadius,
     @required this.iconSize,
+    @required this.selectedWidth,
     this.curve = Curves.linear,
   })  : assert(isSelected != null),
         assert(item != null),
@@ -138,6 +145,7 @@ class _ItemWidget extends StatelessWidget {
         assert(itemCornerRadius != null),
         assert(iconSize != null),
         assert(curve != null),
+        assert(selectedWidth != null),
         super(key: key);
 
   @override
@@ -146,7 +154,7 @@ class _ItemWidget extends StatelessWidget {
       container: true,
       selected: isSelected,
       child: AnimatedContainer(
-        width: isSelected ? 130 : 50,
+        width: isSelected ? selectedWidth : 50,
         height: double.maxFinite,
         duration: animationDuration,
         curve: curve,
@@ -159,7 +167,7 @@ class _ItemWidget extends StatelessWidget {
           scrollDirection: Axis.horizontal,
           physics: NeverScrollableScrollPhysics(),
           child: Container(
-            width: isSelected ? 130 : 50,
+            width: isSelected ? selectedWidth : 50,
             padding: EdgeInsets.symmetric(horizontal: 8),
             child: Row(
               mainAxisSize: MainAxisSize.max,

--- a/lib/bottom_navy_bar.dart
+++ b/lib/bottom_navy_bar.dart
@@ -36,7 +36,7 @@ class BottomNavyBar extends StatelessWidget {
   final int selectedIndex;
 
   // The width of selected item. Defaults to 130.
-  final int selectedWidth;
+  final double selectedWidth;
 
   /// The icon size of all items. Defaults to 24.
   final double iconSize;
@@ -126,7 +126,7 @@ class _ItemWidget extends StatelessWidget {
   final double itemCornerRadius;
   final Duration animationDuration;
   final Curve curve;
-  final int selectedWidth;
+  final double selectedWidth;
 
   const _ItemWidget({
     Key key,

--- a/lib/bottom_navy_bar.dart
+++ b/lib/bottom_navy_bar.dart
@@ -13,7 +13,8 @@ class BottomNavyBar extends StatelessWidget {
   BottomNavyBar({
     Key key,
     this.selectedIndex = 0,
-    this.selectedWidth = 130,
+    this.itemSelectedWidth = 130,
+    this.itemWidth = 50,
     this.showElevation = true,
     this.iconSize = 24,
     this.backgroundColor,
@@ -36,7 +37,10 @@ class BottomNavyBar extends StatelessWidget {
   final int selectedIndex;
 
   // The width of selected item. Defaults to 130.
-  final double selectedWidth;
+  final double itemSelectedWidth;
+
+  // The width of item. Defaults to 50.
+  final double itemWidth;
 
   /// The icon size of all items. Defaults to 24.
   final double iconSize;
@@ -105,9 +109,10 @@ class BottomNavyBar extends StatelessWidget {
                   isSelected: index == selectedIndex,
                   backgroundColor: bgColor,
                   itemCornerRadius: itemCornerRadius,
+                  itemWidth: itemWidth,
+                  itemSelectedWidth: itemSelectedWidth,
                   animationDuration: animationDuration,
                   curve: curve,
-                  selectedWidth: selectedWidth,
                 ),
               );
             }).toList(),
@@ -124,9 +129,10 @@ class _ItemWidget extends StatelessWidget {
   final BottomNavyBarItem item;
   final Color backgroundColor;
   final double itemCornerRadius;
+  final double itemSelectedWidth;
+  final double itemWidth;
   final Duration animationDuration;
   final Curve curve;
-  final double selectedWidth;
 
   const _ItemWidget({
     Key key,
@@ -135,17 +141,19 @@ class _ItemWidget extends StatelessWidget {
     @required this.backgroundColor,
     @required this.animationDuration,
     @required this.itemCornerRadius,
+    @required this.itemWidth,
+    @required this.itemSelectedWidth,
     @required this.iconSize,
-    @required this.selectedWidth,
     this.curve = Curves.linear,
   })  : assert(isSelected != null),
         assert(item != null),
         assert(backgroundColor != null),
         assert(animationDuration != null),
         assert(itemCornerRadius != null),
-        assert(iconSize != null),
+        assert(itemWidth != null),
+        assert(itemSelectedWidth != null),
         assert(curve != null),
-        assert(selectedWidth != null),
+        assert(iconSize != null),
         super(key: key);
 
   @override
@@ -154,7 +162,7 @@ class _ItemWidget extends StatelessWidget {
       container: true,
       selected: isSelected,
       child: AnimatedContainer(
-        width: isSelected ? selectedWidth : 50,
+        width: isSelected ? itemSelectedWidth : itemWidth,
         height: double.maxFinite,
         duration: animationDuration,
         curve: curve,
@@ -167,7 +175,7 @@ class _ItemWidget extends StatelessWidget {
           scrollDirection: Axis.horizontal,
           physics: NeverScrollableScrollPhysics(),
           child: Container(
-            width: isSelected ? selectedWidth : 50,
+            width: isSelected ? itemSelectedWidth : itemWidth,
             padding: EdgeInsets.symmetric(horizontal: 8),
             child: Row(
               mainAxisSize: MainAxisSize.max,


### PR DESCRIPTION
Overflow error appears if 5 tabs are displayed on smaller screen resolutions  such as iPhone SE 
![Simulator Screen Shot - iPhone SE - 2021-01-08 at 14 57 09](https://user-images.githubusercontent.com/11044696/104033903-130f2200-51c8-11eb-8a65-9c1dd627d2b5.png)

Add ability to change the hardcoded item width (default 50) and item (default 130) in order to accommodate smaller screens (for example, reduce selected width to 110 and default width to 40).
 