### PR TITLE
Fixed issue #57 (Configurable decoration for Navigation Items)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,12 +60,20 @@ class _MyHomePageState extends State<MyHomePage> {
             icon: Icon(Icons.apps),
             title: Text('Home'),
             activeColor: Colors.red,
+            decoration: UnderlineTabIndicator(
+              borderSide: BorderSide(width: 3.0, color: Colors.black),
+              insets: EdgeInsets.fromLTRB(0, 1, 10, 1)
+            ),
             textAlign: TextAlign.center,
           ),
           BottomNavyBarItem(
             icon: Icon(Icons.people),
             title: Text('Users'),
             activeColor: Colors.purpleAccent,
+            decoration: BoxDecoration(
+              color: Colors.purpleAccent.withOpacity(0.2),
+              borderRadius: BorderRadius.circular(10),
+            ),
             textAlign: TextAlign.center,
           ),
           BottomNavyBarItem(

--- a/lib/bottom_navy_bar.dart
+++ b/lib/bottom_navy_bar.dart
@@ -90,6 +90,7 @@ class BottomNavyBar extends StatelessWidget {
                 onTap: () => onItemSelected(index),
                 child: _ItemWidget(
                   item: item,
+                  decoration: item.decoration,
                   iconSize: iconSize,
                   isSelected: index == selectedIndex,
                   backgroundColor: bgColor,
@@ -114,8 +115,9 @@ class _ItemWidget extends StatelessWidget {
   final double itemCornerRadius;
   final Duration animationDuration;
   final Curve curve;
+  Decoration? decoration;
 
-  const _ItemWidget({
+  _ItemWidget({
     Key? key,
     required this.item,
     required this.isSelected,
@@ -123,6 +125,7 @@ class _ItemWidget extends StatelessWidget {
     required this.animationDuration,
     required this.itemCornerRadius,
     required this.iconSize,
+    required this.decoration,
     this.curve = Curves.linear,
   }) : super(key: key);
 
@@ -136,10 +139,12 @@ class _ItemWidget extends StatelessWidget {
         height: double.maxFinite,
         duration: animationDuration,
         curve: curve,
-        decoration: BoxDecoration(
-          color:
-              isSelected ? item.activeColor.withOpacity(0.2) : backgroundColor,
-          borderRadius: BorderRadius.circular(itemCornerRadius),
+        decoration: decoration != null
+            ? decoration
+            : BoxDecoration(
+              color:
+                isSelected ? item.activeColor.withOpacity(0.2) : backgroundColor,
+              borderRadius: BorderRadius.circular(itemCornerRadius),
         ),
         child: SingleChildScrollView(
           scrollDirection: Axis.horizontal,
@@ -195,6 +200,7 @@ class BottomNavyBarItem {
     this.activeColor = Colors.blue,
     this.textAlign,
     this.inactiveColor,
+    this.decoration
   });
 
   /// Defines this item's icon which is placed in the right side of the [title].
@@ -209,6 +215,9 @@ class BottomNavyBarItem {
 
   /// The [icon] and [title] color defined when this item is not selected.
   final Color? inactiveColor;
+
+  /// The [decoration] color defined for this item for both selected and not selected states.
+  final Decoration? decoration;
 
   /// The alignment for the [title].
   ///


### PR DESCRIPTION
Added decoration field for both BottomNavyBarItem and _ItemWidget classes so that you can set your desired decoration for any of the items independently.
I used this in example main.dart file for 2 of the items, for the one the decoration is from UnderlineTabIndicator class and the other one is from BoxDecoration class. When no decoration is declared it will be as default.
You can use any class that extends Decoration class as decoration.